### PR TITLE
Jenkinsfile - Increased wait timeout for LBs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,8 +328,8 @@ pipeline {
                             sh "kubectl apply -f ./kubernetes/${KUBE_NAMESPACE}-nlb.yml"
 
                             // Sleep to wait for deployment - Pipeline will fail if you don't wait
-                            echo "Sleeping for 30 seconds..."
-                            sleep time: 30, unit: 'SECONDS'
+                            echo "Sleeping for 180 seconds..."
+                            sleep time: 180, unit: 'SECONDS'
                             // Loop to wait for deployment
                             timeout(time: 5, unit: 'MINUTES') {
                                 waitUntil {
@@ -365,8 +365,8 @@ pipeline {
                             sh "kubectl apply -f ./kubernetes/${KUBE_NAMESPACE}-ingress.yml"
 
                             // Sleep to wait for deployment - Pipeline will fail if you don't wait
-                            echo "Sleeping for 30 seconds..."
-                            sleep time: 30, unit: 'SECONDS'
+                            echo "Sleeping for 180 seconds..."
+                            sleep time: 180, unit: 'SECONDS'
                             // Loop to wait for deployment
                             timeout(time: 5, unit: 'MINUTES') {
                                 waitUntil {


### PR DESCRIPTION
Pipeline ended in failure because the NLB wasn't deployed yet. Increased sleep to 3 minutes. It is the end of the pipeline so waiting for awhile doesn't hurt anything.

Need to get the while loops working so it doesn't bomb out waiting for a resource to deploy.